### PR TITLE
quasi fixed doubles team rank interpolation

### DIFF
--- a/app/doublesRankView/DoublesRankCtrl.js
+++ b/app/doublesRankView/DoublesRankCtrl.js
@@ -47,6 +47,7 @@
           teams[i].winPercent = (teams[i].winNum / (teams[i].winNum + teams[i].lossNum));
         }
         vm.displayedCollection = teams;
+          console.log("display teams", vm.displayedCollection)
       });
     }
 

--- a/app/factories/teamNameCreator.js
+++ b/app/factories/teamNameCreator.js
@@ -32,7 +32,6 @@
 
           teamsArr[0] = team1uid;
           teamsArr[1] = team2uid;
-
           resolve(teamsArr);
 
         });

--- a/app/filters/teamMembers.js
+++ b/app/filters/teamMembers.js
@@ -7,13 +7,16 @@
     teamMembers.$inject = ["fb"];
 
     function teamMembers(fb) {
-      var users = fb.getUsersArr();
+        var users = fb.getUsersArr();
 
-      return function(uid) {
-        var uids = uid.split("-");
-        var p1 = _.find(users, 'uid', uids[0]).userName;
-        var p2 = _.find(users, 'uid', uids[1]).userName;
-
+      return function (uid) {
+          var uids = uid.split("-");
+          console.log("uid", uid)
+          var searchP1UID = uids[0] + "-" + uids[1] + "-" + uids[2] + "-" + uids[3] + "-" + uids[4];
+          var searchP2UID = uids[5] + "-" + uids[6] + "-" + uids[7] + "-" + uids[8] + "-" + uids[9];
+          var p1 = _.find(users, 'uid', searchP1UID).userName;
+          console.log("p1", p1);
+        var p2 = _.find(users, 'uid', searchP2UID).userName;
         return p1 + " & " + p2;
       };
     }


### PR DESCRIPTION
I looked at this for five seconds, didn't have time to investigate why some of the uids coming in are a combination of github uids and some are just the single player uid ... this only solves 60% interpolation issues on doubles ranking page
